### PR TITLE
doc: configure test framework using package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,27 @@ The simplest Continuous-Integration example for Node.js
     brew install npm
     ```
 
-2. Configure `package.json` for the desired testing framework. For example, to use Jest:
+2. Configure `package.json` for the desired testing framework. To use Jest, for example, add the following:
 
-    package.json
     ```bash
     "devDependencies": {
       "jest": "^29.7"
     }
     ```
 
-3. Check the install by running the tests:
+3. Install the test framework configured in 2:
+
+    ```bash
+    npm install
+    ```
+
+4. Perform a clean install:
+
+    ```bash
+    npm ci
+    ```
+
+5. Check the install by running the tests:
 
     ```bash
     npm test

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ The simplest Continuous-Integration example for Node.js
     brew install npm
     ```
 
-2. Install Jest (a popular JavaScript Testing Framework):
+2. Configure `package.json` for the desired testing framework. For example, to use Jest:
 
+    package.json
     ```bash
-    npm install --save-dev jest
+    "devDependencies": {
+      "jest": "^29.7"
+    }
     ```
 
 3. Check the install by running the tests:
@@ -26,7 +29,7 @@ The simplest Continuous-Integration example for Node.js
 
     ```bash
     $ npm test
-    
+
     > test
     > jest
 


### PR DESCRIPTION
# Closes: n/a

## Goal
Make the project more idiomatic by specifying the testing framework with the package manager, using Jest only as an example.

## Approach
1. Replace `npm install jest` with `devDependencies` in `package.json`.
2. Add missing `install` and `ci` steps.
